### PR TITLE
The stub is now opened in the API itself

### DIFF
--- a/space_api/mongo/aggregate.py
+++ b/space_api/mongo/aggregate.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, Any
 from space_api.transport import make_meta, aggregate
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Aggregate:
@@ -7,7 +8,7 @@ class Aggregate:
     The Mongo Aggregate Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
         _pipe = [
             {'$match': {'status': 'A'}},
@@ -17,14 +18,14 @@ class Aggregate:
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
         self.params = {}
@@ -47,7 +48,7 @@ class Aggregate:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return aggregate(self.url, pipeline=self.params['pipe'], operation='one', meta=self.meta)
+        return aggregate(self.stub, pipeline=self.params['pipe'], operation='one', meta=self.meta)
 
     def all(self) -> Dict[str, Any]:
         """
@@ -57,7 +58,7 @@ class Aggregate:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return aggregate(self.url, pipeline=self.params['pipe'], operation='all', meta=self.meta)
+        return aggregate(self.stub, pipeline=self.params['pipe'], operation='all', meta=self.meta)
 
 
 __all__ = ['Aggregate']

--- a/space_api/mongo/delete.py
+++ b/space_api/mongo/delete.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, delete
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Delete:
@@ -8,19 +9,20 @@ class Delete:
     The Mongo Delete Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
         response = db.delete('posts').where(AND(COND('title', '==', 'Title1'))).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
-    def __init__(self, project_id: str, collection: str, url: str, token: Optional[str] = None):
+
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
         self.params = {'find': {}}
@@ -41,7 +43,7 @@ class Delete:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return delete(self.url, find=self.params['find'], operation='one', meta=self.meta)
+        return delete(self.stub, find=self.params['find'], operation='one', meta=self.meta)
 
     def all(self) -> Dict[str, Any]:
         """
@@ -49,7 +51,7 @@ class Delete:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return delete(self.url, find=self.params['find'], operation='all', meta=self.meta)
+        return delete(self.stub, find=self.params['find'], operation='all', meta=self.meta)
 
 
 __all__ = ['Delete']

--- a/space_api/mongo/get.py
+++ b/space_api/mongo/get.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, read, make_read_options
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Get:
@@ -8,20 +9,20 @@ class Get:
     The Mongo Get Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
         response = db.get('posts').where(AND(COND('title', '==', 'Title1'))).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
         self.params = {'find': {}, 'options': {}}
@@ -103,7 +104,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='one', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='one', options=read_options, meta=self.meta)
 
     def all(self) -> Dict[str, Any]:
         """
@@ -121,7 +122,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='all', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='all', options=read_options, meta=self.meta)
 
     def distinct(self, key) -> Dict[str, Any]:
         """
@@ -137,7 +138,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='distinct', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='distinct', options=read_options, meta=self.meta)
 
     def count(self) -> Dict[str, Any]:
         """
@@ -151,7 +152,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='count', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='count', options=read_options, meta=self.meta)
 
 
 __all__ = ['Get']

--- a/space_api/mongo/insert.py
+++ b/space_api/mongo/insert.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, Any
 from space_api.transport import make_meta, create
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Insert:
@@ -7,21 +8,21 @@ class Insert:
     The Mongo Insert Interface
     ::
         from space_api import API
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
         record = {'author': 'John', 'title': 'Title1'}
         response = db.insert('posts').one(record)
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
         self.meta = make_meta(self.project_id, self.db_type, self.collection, self.token)
@@ -36,7 +37,7 @@ class Insert:
         :param record: The record to insert
         :return: (dict{str:Any}) The response dictionary
         """
-        return create(self.url, document=record, operation='one', meta=self.meta)
+        return create(self.stub, document=record, operation='one', meta=self.meta)
 
     def all(self, records) -> Dict[str, Any]:
         """
@@ -48,7 +49,7 @@ class Insert:
         :param records: (list) The records to insert
         :return: (dict{str:Any}) The response dictionary
         """
-        return create(self.url, document=records, operation='all', meta=self.meta)
+        return create(self.stub, document=records, operation='all', meta=self.meta)
 
 
 __all__ = ['Insert']

--- a/space_api/mongo/mongo.py
+++ b/space_api/mongo/mongo.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 from space_api.mongo.get import Get
 from space_api.mongo.insert import Insert
 from space_api.mongo.update import Update
@@ -11,17 +12,17 @@ class Mongo:
     The Mongo Client Interface
     ::
         from space_api import API
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
 
     :param project_id: (str) The project ID
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, url: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
 
@@ -32,7 +33,7 @@ class Mongo:
         :param collection: (str) The collection name
         :return: The Mongo Get object
         """
-        return Get(self.project_id, collection, self.url, self.token)
+        return Get(self.project_id, collection, self.stub, self.token)
 
     def insert(self, collection: str) -> 'Insert':
         """
@@ -41,7 +42,7 @@ class Mongo:
         :param collection: (str) The collection name
         :return: The Mongo Insert object
         """
-        return Insert(self.project_id, collection, self.url, self.token)
+        return Insert(self.project_id, collection, self.stub, self.token)
 
     def update(self, collection: str) -> 'Update':
         """
@@ -50,7 +51,7 @@ class Mongo:
         :param collection: (str) The collection name
         :return: The Mongo Update object
         """
-        return Update(self.project_id, collection, self.url, self.token)
+        return Update(self.project_id, collection, self.stub, self.token)
 
     def delete(self, collection: str) -> 'Delete':
         """
@@ -59,7 +60,7 @@ class Mongo:
         :param collection: (str) The collection name
         :return: The Mongo Delete object
         """
-        return Delete(self.project_id, collection, self.url, self.token)
+        return Delete(self.project_id, collection, self.stub, self.token)
 
     def aggr(self, collection: str) -> 'Aggregate':
         """
@@ -68,7 +69,7 @@ class Mongo:
         :param collection: (str) The collection name
         :return: The Mongo Aggregate object
         """
-        return Aggregate(self.project_id, collection, self.url, self.token)
+        return Aggregate(self.project_id, collection, self.stub, self.token)
 
     def live_query(self, collection: str):
         raise NotImplementedError("Coming Soon!")

--- a/space_api/mongo/update.py
+++ b/space_api/mongo/update.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, update
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Update:
@@ -8,20 +9,20 @@ class Update:
     The Mongo Update Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.mongo()
         response = db.update('posts').where(AND(COND('title', '==', 'Title1'))).set({'title':'Title2'}).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = "mongo"
         self.token = token
         self.params = {'find': {}, 'update': {}}
@@ -156,7 +157,7 @@ class Update:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return update(self.url, find=self.params['find'], operation='one', _update=self.params['update'],
+        return update(self.stub, find=self.params['find'], operation='one', _update=self.params['update'],
                       meta=self.meta)
 
     def all(self) -> Dict[str, Any]:
@@ -165,7 +166,7 @@ class Update:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return update(self.url, find=self.params['find'], operation='all', _update=self.params['update'],
+        return update(self.stub, find=self.params['find'], operation='all', _update=self.params['update'],
                       meta=self.meta)
 
     def upsert(self) -> Dict[str, Any]:
@@ -174,7 +175,7 @@ class Update:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return update(self.url, find=self.params['find'], operation='upsert', _update=self.params['update'],
+        return update(self.stub, find=self.params['find'], operation='upsert', _update=self.params['update'],
                       meta=self.meta)
 
 

--- a/space_api/sql/delete.py
+++ b/space_api/sql/delete.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, delete
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Delete:
@@ -8,21 +9,22 @@ class Delete:
     The SQL Delete Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.my_sql() # For a MySQL interface
         response = db.delete('posts').where(AND(COND('title', '==', 'Title1'))).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param db_type: (str) The database type
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, db_type: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, db_type: str,
+                 token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = db_type
         self.token = token
         self.params = {'find': {}}
@@ -43,7 +45,7 @@ class Delete:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return delete(self.url, find=self.params['find'], operation='all', meta=self.meta)
+        return delete(self.stub, find=self.params['find'], operation='all', meta=self.meta)
 
 
 __all__ = ['Delete']

--- a/space_api/sql/get.py
+++ b/space_api/sql/get.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, read, make_read_options
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Get:
@@ -8,20 +9,22 @@ class Get:
     The SQL Get Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.my_sql() # For a MySQL interface
         response = db.get('posts').where(AND(COND('title', '==', 'Title1'))).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param db_type: (str) The database type
     :param token: (str) The (optional) JWT Token
     """
-    def __init__(self, project_id: str, collection: str, url: str, db_type: str, token: Optional[str] = None):
+
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, db_type: str,
+                 token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = db_type
         self.token = token
         self.params = {'find': {}, 'options': {}}
@@ -108,7 +111,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='one', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='one', options=read_options, meta=self.meta)
 
     def all(self) -> Dict[str, Any]:
         """
@@ -126,7 +129,7 @@ class Get:
         read_options = make_read_options(select=options.get('select'), sort=options.get('sort'),
                                          skip=options.get('skip'), limit=options.get('limit'),
                                          distinct=options.get('distinct'))
-        return read(self.url, find=self.params['find'], operation='all', options=read_options, meta=self.meta)
+        return read(self.stub, find=self.params['find'], operation='all', options=read_options, meta=self.meta)
 
 
 __all__ = ['Get']

--- a/space_api/sql/insert.py
+++ b/space_api/sql/insert.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, Any
 from space_api.transport import make_meta, create
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Insert:
@@ -7,22 +8,23 @@ class Insert:
     The SQL Insert Interface
     ::
         from space_api import API
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.my_sql() # For a MySQL interface
         record = {'author': 'John', 'title': 'Title1'}
         response = db.insert('posts').one(record)
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param db_type: (str) The database type
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, db_type: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, db_type: str,
+                 token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = db_type
         self.token = token
         self.meta = make_meta(self.project_id, self.db_type, self.collection, self.token)
@@ -37,7 +39,7 @@ class Insert:
         :param record: The record to insert
         :return: (dict{str:Any}) The response dictionary
         """
-        return create(self.url, document=record, operation='one', meta=self.meta)
+        return create(self.stub, document=record, operation='one', meta=self.meta)
 
     def all(self, records) -> Dict[str, Any]:
         """
@@ -49,7 +51,7 @@ class Insert:
         :param records: (list) The records to insert
         :return: (dict{str:Any}) The response dictionary
         """
-        return create(self.url, document=records, operation='all', meta=self.meta)
+        return create(self.stub, document=records, operation='all', meta=self.meta)
 
 
 __all__ = ['Insert']

--- a/space_api/sql/sql.py
+++ b/space_api/sql/sql.py
@@ -3,6 +3,7 @@ from space_api.sql.get import Get
 from space_api.sql.insert import Insert
 from space_api.sql.update import Update
 from space_api.sql.delete import Delete
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class SQL:
@@ -10,27 +11,27 @@ class SQL:
     The SQL Client Interface
     ::
         from space_api import API
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.my_sql() # For a MySQL interface
         db = api.postgres() # For a Postgres interface
 
     :param project_id: (str) The project ID
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param db_type: (str) The database type
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, url: str, db_type: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, stub: SpaceCloudStub, db_type: str, token: Optional[str] = None):
         self.project_id = project_id
-        self.url = url
+        self.stub = stub
         self.db_type = db_type
         self.token = token
 
     def __str__(self):
         if self.db_type == 'sql-mysql':
-            return f'SpaceAPI MySQL(project_id:{self.project_id}, url:{self.url}, token:{self.token})'
+            return f'SpaceAPI MySQL(project_id:{self.project_id}, stub:{self.stub}, token:{self.token})'
         elif self.db_type == 'sql-postgres':
-            return f'SpaceAPI Postgres(project_id:{self.project_id}, url:{self.url}, token:{self.token})'
+            return f'SpaceAPI Postgres(project_id:{self.project_id}, stub:{self.stub}, token:{self.token})'
 
     def get(self, collection: str) -> 'Get':
         """
@@ -39,7 +40,7 @@ class SQL:
         :param collection: (str) The collection name
         :return: The SQL Get object
         """
-        return Get(self.project_id, collection, self.url, self.db_type, self.token)
+        return Get(self.project_id, collection, self.stub, self.db_type, self.token)
 
     def insert(self, collection: str) -> 'Insert':
         """
@@ -48,7 +49,7 @@ class SQL:
         :param collection: (str) The collection name
         :return: The SQL Insert object
         """
-        return Insert(self.project_id, collection, self.url, self.db_type, self.token)
+        return Insert(self.project_id, collection, self.stub, self.db_type, self.token)
 
     def update(self, collection: str) -> 'Update':
         """
@@ -57,7 +58,7 @@ class SQL:
         :param collection: (str) The collection name
         :return: The SQL Update object
         """
-        return Update(self.project_id, collection, self.url, self.db_type, self.token)
+        return Update(self.project_id, collection, self.stub, self.db_type, self.token)
 
     def delete(self, collection: str) -> 'Delete':
         """
@@ -66,7 +67,7 @@ class SQL:
         :param collection: (str) The collection name
         :return: The SQL Delete object
         """
-        return Delete(self.project_id, collection, self.url, self.db_type, self.token)
+        return Delete(self.project_id, collection, self.stub, self.db_type, self.token)
 
     def live_query(self, collection: str):
         raise NotImplementedError("Coming Soon!")

--- a/space_api/sql/update.py
+++ b/space_api/sql/update.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 from space_api.utils import generate_find, AND
 from space_api.transport import make_meta, update
+from space_api.proto.server_pb2_grpc import SpaceCloudStub
 
 
 class Update:
@@ -8,21 +9,22 @@ class Update:
     The SQL Update Interface
     ::
         from space_api import API, AND, OR, COND
-        api = API("My-Project", "http://localhost:8080")
+        api = API("My-Project", "localhost:8080")
         db = api.my_sql() # For a MySQL interface
         response = db.update('posts').where(AND(COND('title', '==', 'Title1'))).set({'title':'Title2'}).all()
 
     :param project_id: (str) The project ID
     :param collection: (str) The collection name
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param db_type: (str) The database type
     :param token: (str) The (optional) JWT Token
     """
 
-    def __init__(self, project_id: str, collection: str, url: str, db_type: str, token: Optional[str] = None):
+    def __init__(self, project_id: str, collection: str, stub: SpaceCloudStub, db_type: str,
+                 token: Optional[str] = None):
         self.project_id = project_id
         self.collection = collection
-        self.url = url
+        self.stub = stub
         self.db_type = db_type
         self.token = token
         self.params = {'find': {}, 'update': {}}
@@ -52,7 +54,7 @@ class Update:
 
         :return: (dict{str:Any})  The response dictionary
         """
-        return update(self.url, find=self.params['find'], operation='all', _update=self.params['update'],
+        return update(self.stub, find=self.params['find'], operation='all', _update=self.params['update'],
                       meta=self.meta)
 
 

--- a/space_api/transport.py
+++ b/space_api/transport.py
@@ -55,11 +55,11 @@ def make_read_options(select: Dict[str, int], sort: Dict[str, int], skip: int, l
     return server_pb2.ReadOptions(select=select, sort=sort, skip=skip, limit=limit, distinct=distinct)
 
 
-def create(url: str, document, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
+def create(stub: server_pb2_grpc.SpaceCloudStub, document, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
     """
     Calls the gRPC Create function
 
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param document: The document to create
     :param operation: (str) The operation to perform
     :param meta: (server_pb2.Meta) The gRPC Meta object
@@ -67,16 +67,14 @@ def create(url: str, document, operation: str, meta: server_pb2.Meta) -> Dict[st
     """
     document = _obj_to_utf8_bytes(document)
     create_request = server_pb2.CreateRequest(document=document, operation=operation, meta=meta)
-    with grpc.insecure_channel(url) as channel:
-        stub = server_pb2_grpc.SpaceCloudStub(channel)
-        return _get_response_dict(stub.Create(create_request))
+    return _get_response_dict(stub.Create(create_request))
 
 
-def read(url: str, find, operation: str, options: server_pb2.ReadOptions, meta: server_pb2.Meta) -> Dict[str, Any]:
+def read(stub: server_pb2_grpc.SpaceCloudStub, find, operation: str, options: server_pb2.ReadOptions, meta: server_pb2.Meta) -> Dict[str, Any]:
     """
     Calls the gRPC Read function
     
-    :param url: (str) The project URL 
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub 
     :param find: The find parameters
     :param operation: (str) The operation to perform
     :param options: (server_pb2.ReadOptions) 
@@ -85,16 +83,14 @@ def read(url: str, find, operation: str, options: server_pb2.ReadOptions, meta: 
     """
     find = _obj_to_utf8_bytes(find)
     read_request = server_pb2.ReadRequest(find=find, operation=operation, options=options, meta=meta)
-    with grpc.insecure_channel(url) as channel:
-        stub = server_pb2_grpc.SpaceCloudStub(channel)
-        return _get_response_dict(stub.Read(read_request))
+    return _get_response_dict(stub.Read(read_request))
 
 
-def update(url: str, find, operation: str, _update, meta: server_pb2.Meta) -> Dict[str, Any]:
+def update(stub: server_pb2_grpc.SpaceCloudStub, find, operation: str, _update, meta: server_pb2.Meta) -> Dict[str, Any]:
     """
     Calls the gRPC Update function
 
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param find: The find parameters
     :param operation: (str) The operation to perform
     :param _update: The update parameters
@@ -104,16 +100,14 @@ def update(url: str, find, operation: str, _update, meta: server_pb2.Meta) -> Di
     find = _obj_to_utf8_bytes(find)
     _update = _obj_to_utf8_bytes(_update)
     update_request = server_pb2.UpdateRequest(find=find, operation=operation, update=_update, meta=meta)
-    with grpc.insecure_channel(url) as channel:
-        stub = server_pb2_grpc.SpaceCloudStub(channel)
-        return _get_response_dict(stub.Update(update_request))
+    return _get_response_dict(stub.Update(update_request))
 
 
-def delete(url: str, find, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
+def delete(stub: server_pb2_grpc.SpaceCloudStub, find, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
     """
     Calls the gRPC Delete function
 
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param find: The find parameters
     :param operation: (str) The operation to perform
     :param meta: (server_pb2.Meta) The gRPC Meta object
@@ -121,16 +115,14 @@ def delete(url: str, find, operation: str, meta: server_pb2.Meta) -> Dict[str, A
     """
     find = _obj_to_utf8_bytes(find)
     delete_request = server_pb2.DeleteRequest(find=find, operation=operation, meta=meta)
-    with grpc.insecure_channel(url) as channel:
-        stub = server_pb2_grpc.SpaceCloudStub(channel)
-        return _get_response_dict(stub.Delete(delete_request))
+    return _get_response_dict(stub.Delete(delete_request))
 
 
-def aggregate(url: str, pipeline, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
+def aggregate(stub: server_pb2_grpc.SpaceCloudStub, pipeline, operation: str, meta: server_pb2.Meta) -> Dict[str, Any]:
     """
     Calls the gRPC Aggregate function
 
-    :param url: (str) The project URL
+    :param stub: (server_pb2_grpc.SpaceCloudStub) The gRPC endpoint stub
     :param pipeline: The pipeline parameters
     :param operation: (str) The operation to perform
     :param meta: (server_pb2.Meta) The gRPC Meta object
@@ -138,6 +130,4 @@ def aggregate(url: str, pipeline, operation: str, meta: server_pb2.Meta) -> Dict
     """
     pipeline = _obj_to_utf8_bytes(pipeline)
     aggregate_request = server_pb2.AggregateRequest(pipeline=pipeline, operation=operation, meta=meta)
-    with grpc.insecure_channel(url) as channel:
-        stub = server_pb2_grpc.SpaceCloudStub(channel)
-        return _get_response_dict(stub.Aggregate(aggregate_request))
+    return _get_response_dict(stub.Aggregate(aggregate_request))

--- a/test/my_sql.py
+++ b/test/my_sql.py
@@ -6,48 +6,50 @@ db = api.my_sql()
 
 # insert - 2/2 passing
 # one
-# print(db.insert('books').one({"name": "MyBook", "author": "John Doe"}))
+print(db.insert('books').one({"name": "MyBook", "author": "John Doe"}))
 # all
-# print(db.insert('books').all([{"name": "BookName"}, {"name": "BookName"}]))
+print(db.insert('books').all([{"name": "BookName"}, {"name": "BookName"}]))
 
 # delete - 2/2 passing
 # all
-# print(db.delete('books').all())
+print(db.delete('books').all())
 # where, all
-# print(db.delete('books').where(COND('name', '!=', 'Book_name')).all())
+print(db.delete('books').where(COND('name', '!=', 'Book_name')).all())
 
 # get - 12/12 passing
 # all
-# print(db.get('books').all())
+print(db.get('books').all())
 # one
-# print(db.get('books').one())
+print(db.get('books').one())
 # limit all
-# print(db.get('books').limit(2).all())
+print(db.get('books').limit(2).all())
 # limit one
-# print(db.get('books').limit(2).one())
+print(db.get('books').limit(2).one())
 # skip all
-# print(db.get('books').skip(2).all())
+print(db.get('books').skip(2).all())
 # skip one
-# print(db.get('books').skip(2).one())
+print(db.get('books').skip(2).one())
 # sort all
-# print(db.get('books').sort('-author').all())
+print(db.get('books').sort('-author').all())
 # sort one
-# print(db.get('books').sort('author').one())
+print(db.get('books').sort('author').one())
 # select all
-# print(db.get('books').select({'author': 1}).all())
+print(db.get('books').select({'author': 1}).all())
 # select one
-# print(db.get('books').select({'author': 1}).one())
+print(db.get('books').select({'author': 1}).one())
 # where all
-# print(db.get('books').where(COND("name", "==", "Book_name")).all())
+print(db.get('books').where(COND("name", "==", "Book_name")).all())
 # where one
-# print(db.get('books').where(COND("name", "==", "Book_name")).one())
+print(db.get('books').where(COND("name", "==", "BookName")).one())
 
 
 # update - 2/2 passing
 # set all
 print(db.update('books').set({"author": "myself"}).all())
 # set where all
-# print(db.update('books').where(COND("author", "==", "some_author")).set({"author": "myself"}).all())
+print(db.update('books').where(COND("author", "==", "some_author")).set({"author": "myself"}).all())
 
 # testing
 print(db.get('books').all())
+
+api.close()


### PR DESCRIPTION
Instead of Passing the URL to the transport module and then opening and closing the connection there, the connection is now opened as soon as the API is initialized. This will remove the overhead of opening and closing the connection again and again.  
However, the connection will have to be explicitly closed by calling `api.close()`